### PR TITLE
minor: multi modules

### DIFF
--- a/template/{{cookiecutter.project_name}}/modules/default/settings.py
+++ b/template/{{cookiecutter.project_name}}/modules/default/settings.py
@@ -1,6 +1,4 @@
-from config.default import INSTALLED_APPS
-
-INSTALLED_APPS += (
+INSTALLED_APPS = (
     "modules.default.entry",
     "modules.default.example",
 )


### PR DESCRIPTION
1. Optimize compatibility for simultaneous deployment of multiple modules
2. By default, only one module is deployed, and `__all__` declaration is required to deploy multiple modules