### PR TITLE
fix: 软删除基类模型的 get_queryset 方法获取到的数据没有排除已删除数据

### DIFF
--- a/template/{{cookiecutter.project_name}}/core/models.py
+++ b/template/{{cookiecutter.project_name}}/core/models.py
@@ -168,7 +168,7 @@ class SoftDeleteModelManager(OperateRecordModelManager):
 
     def get_queryset(self):
         """获取queryset"""
-        return SoftDeleteQuerySet(self.model, using=self._db)
+        return SoftDeleteQuerySet(self.model, using=self._db).filter(is_deleted=False)
 
 
 class SoftDeleteModel(OperateRecordModel):


### PR DESCRIPTION
调用objects.get_queryset()、objects.values()、objects.values_list()过滤is_deleted=False