### PR TITLE
docs: 更新使用文档 #59

### DIFF
--- a/docs/modules/resource/README.md
+++ b/docs/modules/resource/README.md
@@ -47,7 +47,7 @@ class AnotherPermissionResource(Resource):
 
 ### 多条数据
 
-返回多条数据时，需要在 Resource 类中声明 `many_response = True`
+返回多条数据时，需要在 Resource 类中声明 `many_response_data = True`
 
 1. 一个列表，列表中的每一个元素是符合 ResponseSerializer 格式的 dict 对象
 2. ORM Model QuerySet（必须提供 ResponseSerializer 且 ResponseSerializer 继承自 ModelSerializer）

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,4 +14,4 @@ pytest-mock==3.6.1
 faker==14.2.1
 xmlrunner==1.7.7
 pyparsing==2.2.0
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
Cython版本已经不支持PyYAML 6.0了，改成PyYAML==6.0.1可以解决
Resource的README.md中，返回多条数据应声明many_response_data=True而非many_response=True