### PR TITLE
ci: 优化本地与 Actions 流程，提升 act 兼容性

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -2,28 +2,29 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions:
   contents: read
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10.5'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        if: ${{ !env.ACT }}
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,13 +11,12 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -27,12 +26,13 @@ jobs:
           pip install -r requirements_dev.txt
       - name: Test with pytest
         run: |
-          export PYTHONPATH=$PYTHONPATH:"./bk-resource"
+          export PYTHONPATH=$PYTHONPATH:"./bk_resource"
           export PYTHONPATH=$PYTHONPATH:"./tests"
           export DJANGO_SETTINGS_MODULE=tests.settings
           export BK_APP_CONFIG_PATH=tests.config
           pytest -vs tests --disable-warnings --cov=.
       - name: Upload coverage to Codecov
+        if: ${{ !env.ACT }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: ci-local venv install test clean lint-actions ci-check clean-artifacts
+
+# Python interpreter; override with `make PY=python3.10 ci-local` if needed
+PY ?= python3
+VENV := venv
+PIP := $(VENV)/bin/pip
+PYTEST := $(VENV)/bin/pytest
+
+venv:
+	@$(PY) -m venv $(VENV)
+	@$(VENV)/bin/python -m pip install --upgrade pip
+
+install: venv
+	@$(PIP) install -r requirements.txt
+	@$(PIP) install -r requirements_dev.txt
+
+test: install
+	@PYTHONPATH="$$PYTHONPATH:./bk_resource:./tests" \
+	DJANGO_SETTINGS_MODULE=tests.settings \
+	BK_APP_CONFIG_PATH=tests.config \
+	$(PYTEST) -vs tests --disable-warnings --cov=.
+
+ci-local:
+	@$(MAKE) --no-print-directory test; ec=$$?; \
+	sleep 1; \
+	$(MAKE) --no-print-directory clean-artifacts; \
+	exit $$ec
+
+clean-artifacts:
+	rm -rf .pytest_cache .mypy_cache htmlcov \
+		.coverage coverage.xml .coverage.*
+
+clean: clean-artifacts
+	rm -rf dist build
+
+# Lint GitHub Actions workflows with actionlint
+lint-actions:
+	@command -v actionlint >/dev/null 2>&1 || { \
+		echo "actionlint not found. Install with: brew install actionlint"; \
+		exit 1; \
+	}
+	@actionlint -color
+
+# Run both actionlint and tests
+ci-check: lint-actions test


### PR DESCRIPTION
1. workflows/unittest: 统一 Python 为 3.10；在 act 环境跳过 Codecov
2. workflows/publish_pypi: 统一 Python 为 3.10；在 act 环境跳过发布
3. Makefile: 新增 ci-local/test/install/venv/clean；新增 lint-actions/ci-check