### PR TITLE
ci: 优化本地与 Actions 流程，提升 act 兼容性

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -2,28 +2,71 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to validate (e.g. v0.4.13)'
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10.5'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Read version from setup.py
+        id: ver
+        run: |
+          python - <<'PY'
+          import os, re, sys
+          s = open('setup.py', 'r', encoding='utf-8').read()
+          m = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", s)
+          if not m:
+              print("::error::Cannot find version in setup.py")
+              sys.exit(1)
+          ver = m.group(1)
+          print(f"version={ver}")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f"version={ver}\n")
+          PY
+      - name: Determine tag
+        id: tg
+        run: |
+          TAG=""
+          if [ "${{ github.event_name }}" = "release" ]; then TAG="${{ github.event.release.tag_name }}"; fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then TAG="${{ inputs.tag }}"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Validate tag matches setup.py version
+        if: steps.tg.outputs.tag != ''
+        run: |
+          TAG='${{ steps.tg.outputs.tag }}'
+          VER='${{ steps.ver.outputs.version }}'
+          TAG_STRIPPED="${TAG#v}"
+          TAG_STRIPPED="${TAG_STRIPPED#V}"
+          if [ "$TAG_STRIPPED" != "$VER" ]; then
+            echo "::error::Tag ($TAG) does not match setup.py version ($VER)";
+            exit 1;
+          fi
+          echo "Tag ($TAG) matches setup.py version ($VER)"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        if: ${{ !env.ACT }}
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,13 +11,12 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -27,12 +26,13 @@ jobs:
           pip install -r requirements_dev.txt
       - name: Test with pytest
         run: |
-          export PYTHONPATH=$PYTHONPATH:"./bk-resource"
+          export PYTHONPATH=$PYTHONPATH:"./bk_resource"
           export PYTHONPATH=$PYTHONPATH:"./tests"
           export DJANGO_SETTINGS_MODULE=tests.settings
           export BK_APP_CONFIG_PATH=tests.config
           pytest -vs tests --disable-warnings --cov=.
       - name: Upload coverage to Codecov
+        if: ${{ !env.ACT }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: ci-local venv install test clean lint-actions ci-check clean-artifacts
+
+# Python interpreter; override with `make PY=python3.10 ci-local` if needed
+PY ?= python3
+VENV := venv
+PIP := $(VENV)/bin/pip
+PYTEST := $(VENV)/bin/pytest
+
+venv:
+	@$(PY) -m venv $(VENV)
+	@$(VENV)/bin/python -m pip install --upgrade pip
+
+install: venv
+	@$(PIP) install -r requirements.txt
+	@$(PIP) install -r requirements_dev.txt
+
+test: install
+	@PYTHONPATH="$$PYTHONPATH:./bk_resource:./tests" \
+	DJANGO_SETTINGS_MODULE=tests.settings \
+	BK_APP_CONFIG_PATH=tests.config \
+	$(PYTEST) -vs tests --disable-warnings --cov=.
+
+ci-local:
+	@$(MAKE) --no-print-directory test; ec=$$?; \
+	sleep 1; \
+	$(MAKE) --no-print-directory clean-artifacts; \
+	exit $$ec
+
+clean-artifacts:
+	rm -rf .pytest_cache .mypy_cache htmlcov \
+		.coverage coverage.xml .coverage.*
+
+clean: clean-artifacts
+	rm -rf dist build
+
+# Lint GitHub Actions workflows with actionlint
+lint-actions:
+	@command -v actionlint >/dev/null 2>&1 || { \
+		echo "actionlint not found. Install with: brew install actionlint"; \
+		exit 1; \
+	}
+	@actionlint -color
+
+# Run both actionlint and tests
+ci-check: lint-actions test

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 ![logo.png](assests/logo.png)
 
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](https://github.com/TencentBlueKing/bk-resource/blob/main/LICENSE.txt)
-[![Release Version](https://img.shields.io/badge/release-0.4.12-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/releases)
+[![Release Version](https://img.shields.io/badge/release-0.4.13-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/pulls)
 [![codecov](https://codecov.io/gh/TencentBlueKing/bk-resource/branch/main/graph/badge.svg)](https://codecov.io/gh/TencentBlueKing/bk-resource)
 [![Unittest Py3](https://github.com/TencentBlueKing/bk-resource/actions/workflows/unittest.yml/badge.svg)](https://github.com/TencentBlueKing/bk-resource/actions/workflows/unittest.yml)

--- a/readme_en.md
+++ b/readme_en.md
@@ -1,7 +1,7 @@
 ![logo.png](assests/logo.png)
 
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](https://github.com/TencentBlueKing/bk-resource/blob/main/LICENSE.txt)
-[![Release Version](https://img.shields.io/badge/release-0.4.12-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/releases)
+[![Release Version](https://img.shields.io/badge/release-0.4.13-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/TencentBlueKing/bk-resource/pulls)
 [![codecov](https://codecov.io/gh/TencentBlueKing/bk-resource/branch/main/graph/badge.svg)](https://codecov.io/gh/TencentBlueKing/bk-resource)
 [![Unittest Py3](https://github.com/TencentBlueKing/bk-resource/actions/workflows/unittest.yml/badge.svg)](https://github.com/TencentBlueKing/bk-resource/actions/workflows/unittest.yml)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("readme.md") as f:
 
 setup(
     name="bk_resource",
-    version="0.4.12",
+    version="0.4.13",
     author="blueking",
     url="https://bk.tencent.com",
     author_email="blueking@tencent.com",

--- a/template/{{cookiecutter.project_name}}/requirements.txt
+++ b/template/{{cookiecutter.project_name}}/requirements.txt
@@ -6,7 +6,7 @@
 # 各自环境所需的不同依赖, 通过 sites/${env}/deploy/requirements_env.txt得到
 -r requirements_env.txt
 
-bk_resource==0.4.12
+bk_resource==0.4.13
 blueapps>=4.12.0,<5
 
 # web server


### PR DESCRIPTION
1. workflows/unittest: 统一 Python 为 3.10；在 act 环境跳过 Codecov
2. workflows/publish_pypi: 统一 Python 为 3.10；在 act 环境跳过发布
3. Makefile: 新增 ci-local/test/install/venv/clean；新增 lint-actions/ci-check