### PR TITLE
feat(tools): support Json type for DRF JSONField and render as {Json}

### DIFF
--- a/bk_resource/tools.py
+++ b/bk_resource/tools.py
@@ -40,6 +40,7 @@ class FieldType(object):
     OBJECT = "Object"
     ARRAY = "Array"
     ENUM = "Enum"
+    JSON = "Json"
 
 
 def get_serializer_fields(serializer_class):
@@ -85,6 +86,11 @@ def field_to_schema(field):
         type_params = {
             "type": FieldType.OBJECT,
             "properties": OrderedDict([(key, field_to_schema(value)) for key, value in list(field.fields.items())]),
+        }
+    elif isinstance(field, serializers.JSONField):
+        # Represent DRF JSONField as Json type in schema
+        type_params = {
+            "type": FieldType.JSON,
         }
     # elif isinstance(field, serializers.ManyRelatedField):
     #     type_params = {

--- a/tests/constants/tools.py
+++ b/tests/constants/tools.py
@@ -113,7 +113,7 @@ DEFAULT_SCHEMA_RESULT = [
         "description": "Int field",
     },
     {
-        "type": "String",
+        "type": "Json",
         "required": True,
         "name": "json_field",
         "source_name": "json_field",
@@ -130,5 +130,5 @@ DEFAULT_RENDER_LIST = [
     "{Boolean} bool_field Bool field",
     "{Number} float_field Float field",
     "{Integer} int_field Int field",
-    "{String} json_field Json field",
+    "{Json} json_field Json field",
 ]


### PR DESCRIPTION
- Map serializers.JSONField to FieldType.JSON
- Keep nested serializer properties as dict for stable comparisons
- Update tests to expect {Json} rendering and schema type

BREAKING CHANGE: JSONField is now exposed as Json type in schema and render output, not String.